### PR TITLE
Set last entry to endtype. Fixed width issue.

### DIFF
--- a/lib/components/timetablelistentry.dart
+++ b/lib/components/timetablelistentry.dart
@@ -37,7 +37,7 @@ class TimeTableListEntry extends StatelessWidget {
                           alignment: Alignment.bottomCenter,
                           child: Container(
                             height: 25,
-                            width: 25,
+                            width: 5,
                             color: backgroundColour,
                           ),
                         )
@@ -47,7 +47,7 @@ class TimeTableListEntry extends StatelessWidget {
                           alignment: Alignment.topCenter,
                           child: Container(
                             height: 25,
-                            width: 25,
+                            width: 5,
                             color: backgroundColour,
                           ),
                         )

--- a/lib/services/lookup/lookupservice.dart
+++ b/lib/services/lookup/lookupservice.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:http/http.dart';
 import 'package:randomtransport/utils/types/connection.dart';
 import 'package:randomtransport/utils/types/station.dart';
+import 'package:randomtransport/utils/types/stationtype.dart';
 
 class LookupService {
   final String baseURL = "https://transport.opendata.ch/v1";
@@ -60,6 +61,7 @@ class LookupService {
           }
           journey = journey.sublist(0, rand);
         }
+        journey.last.type=StationType.END;
         return Connection(
           journey: journey,
           number: connection["number"],

--- a/lib/utils/types/station.dart
+++ b/lib/utils/types/station.dart
@@ -21,9 +21,7 @@ class Station {
     if(json["arrivalTimestamp"]!=null) {
       DateTime arrivalTimestamp=DateTime.fromMillisecondsSinceEpoch(json["arrivalTimestamp"]*1000);
       arrival="${arrivalTimestamp.hour}:${arrivalTimestamp.minute}";
-      type=StationType.NORMAL;
     } else {
-      type=StationType.START;
       arrival="";
     }
 
@@ -31,8 +29,9 @@ class Station {
       DateTime departureTimestamp=DateTime.fromMillisecondsSinceEpoch(json["departureTimestamp"]*1000);
       departure="${departureTimestamp.hour}:${departureTimestamp.minute}";
     } else {
-      type=StationType.END;
       departure="";
     }
+
+    type=StationType.NORMAL;
   }
 }


### PR DESCRIPTION
Set `StationType` of the last entry in journey object to `END`. Also fixed an issue introduced by #10 where the width was big enough to shift the line.